### PR TITLE
Add and use exe_ctx parameter to commands

### DIFF
--- a/lldb_commands/breakifonfunc.py
+++ b/lldb_commands/breakifonfunc.py
@@ -20,7 +20,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
         'command script add -f breakifonfunc.breakifonfunc biof')
 
-def breakifonfunc(debugger, command, result, internal_dict):
+def breakifonfunc(debugger, command, exe_ctx, result, internal_dict):
     '''
     usage: biof [ModuleName] regex1 ||| [ModuleName2] regex2
     Regex breakpoint that stops only if the second regex breakpoint is in the stack trace

--- a/lldb_commands/breakifonfunc.py
+++ b/lldb_commands/breakifonfunc.py
@@ -39,7 +39,7 @@ def breakifonfunc(debugger, command, exe_ctx, result, internal_dict):
     #     result.SetError(parser.usage)
     #     return 
 
-    target = debugger.GetSelectedTarget()
+    target = exe_ctx.target
     # if len(command.split('|||')) != 2:
     #     result.SetError(parser.usage)
 
@@ -50,7 +50,6 @@ def breakifonfunc(debugger, command, exe_ctx, result, internal_dict):
     else:
         breakpoint = target.BreakpointCreateByRegex(clean_command[0], None)
 
-    target = ds.getTarget()
     moduleName = t[1].strip().split()[1]
     module = target.module[moduleName] 
     if not module:

--- a/lldb_commands/dclass.py
+++ b/lldb_commands/dclass.py
@@ -34,7 +34,7 @@ def __lldb_init_module(debugger, internal_dict):
         'command script add -f dclass.dclass dclass')
 
 
-def dclass(debugger, command, result, internal_dict):
+def dclass(debugger, command, exe_ctx, result, internal_dict):
     '''
     Dumps all the NSObject inherited classes in the process. If you give it a module, 
     it will dump only the classes within that module. You can also filter out classes 

--- a/lldb_commands/dclass.py
+++ b/lldb_commands/dclass.py
@@ -90,26 +90,26 @@ def dclass(debugger, command, exe_ctx, result, internal_dict):
 
     res = lldb.SBCommandReturnObject()
     interpreter = debugger.GetCommandInterpreter()
-    target = debugger.GetSelectedTarget()
+    target = exe_ctx.target
     if options.dump_code_output:
-        directory = '/tmp/{}_{}/'.format(ds.getTarget().executable.basename, datetime.datetime.now().time())
+        directory = '/tmp/{}_{}/'.format(target.executable.basename, datetime.datetime.now().time())
         os.makedirs(directory)
 
-        modules = ds.getTarget().modules
+        modules = target.modules
         if len(args) > 0 and args[0] == '__all':
             os.makedirs(directory + 'PrivateFrameworks')
             os.makedirs(directory + 'Frameworks')
-            modules = [i for i in ds.getTarget().modules if '/usr/lib/' not in i.file.fullpath and '__lldb_' not in i.file.fullpath]
+            modules = [i for i in target.modules if '/usr/lib/' not in i.file.fullpath and '__lldb_' not in i.file.fullpath]
             outputMsg = "Dumping all private Objective-C frameworks"
         elif len(args) > 0 and args[0]:
-            module = ds.getTarget().module[args[0]]
+            module = target.module[args[0]]
             if module is None:
                 result.SetError( "Unable to open module name '{}', to see list of images use 'image list -b'".format(args[0]))
                 return
             modules = [module]
             outputMsg = "Dumping all private Objective-C frameworks"
         else:
-            modules = [ds.getTarget().module[ds.getTarget().executable.fullpath]]
+            modules = [target.module[target.executable.fullpath]]
 
         for module in modules:
             command_script = generate_module_header_script(options, module.file.fullpath.replace('//', '/'))
@@ -147,7 +147,7 @@ def dclass(debugger, command, exe_ctx, result, internal_dict):
     if options.generate_header or options.generate_protocol:
         command_script = generate_header_script(options, clean_command)
     else:
-        command_script = generate_class_dump(debugger, options, clean_command)
+        command_script = generate_class_dump(target, options, clean_command)
 
     if options.generate_header or options.generate_protocol:
         interpreter.HandleCommand('expression -lobjc -O -- (Class)NSClassFromString(@\"{}\")'.format(clean_command), res)
@@ -184,7 +184,7 @@ def dclass(debugger, command, exe_ctx, result, internal_dict):
             result.AppendMessage(res.GetOutput())
 
 
-def generate_class_dump(debugger, options, clean_command=None):
+def generate_class_dump(target, options, clean_command=None):
     command_script = r'''
   @import ObjectiveC;
   @import Foundation;
@@ -213,7 +213,7 @@ def generate_class_dump(debugger, options, clean_command=None):
         command_script += 'objc_getClass(allClasses[i]);' if clean_command else 'allClasses[i];'
 
     if options.module is not None: 
-        command_script += generate_module_search_sections_string(options.module, debugger, options.search_protocols)
+        command_script += generate_module_search_sections_string(options.module, target, options.search_protocols)
 
     if not options.search_protocols and options.conforms_to_protocol is not None:
       command_script +=  'if (!class_conformsToProtocol(cls, NSProtocolFromString(@"'+ options.conforms_to_protocol + '"))) { continue; }'
@@ -281,9 +281,7 @@ def generate_class_dump(debugger, options, clean_command=None):
         command_script += '\n  free(allProtocols);\n  [classesString description];'
     return command_script
 
-def generate_module_search_sections_string(module_name, debugger, useProtocol=False):
-    target = debugger.GetSelectedTarget()
-
+def generate_module_search_sections_string(module_name, target, useProtocol=False):
     module = target.FindModule(lldb.SBFileSpec(module_name))
     if not module.IsValid():
         result.SetError(

--- a/lldb_commands/disassemble.py
+++ b/lldb_commands/disassemble.py
@@ -11,7 +11,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
     'command script add -f disassemble.handle_command dd')
 
-def handle_command(debugger, command, result, internal_dict):
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
     '''
     Disassemble with colors! Terminal only
     '''

--- a/lldb_commands/disassemble.py
+++ b/lldb_commands/disassemble.py
@@ -17,7 +17,7 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
     '''
 
     command_args = shlex.split(command, posix=False)
-    target = ds.getTarget()
+    target = exe_ctx.target
     parser = generate_option_parser()
     try:
         (options, args) = parser.parse_args(command_args)
@@ -33,16 +33,16 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
         query = options.search_functions
         symbol_context_list = target.FindGlobalFunctions(query, 0, lldb.eMatchTypeRegex)    
         for symContext in symbol_context_list:
-            output += generateAssemblyFromSymbol(symContext.symbol, options)
+            output += generateAssemblyFromSymbol(symContext.symbol, options, exe_ctx)
     elif len(args) == 0:
-        sym = ds.getFrame().GetSymbol()
-        output += generateAssemblyFromSymbol(sym, options)
+        sym = exe_ctx.frame.symbol
+        output += generateAssemblyFromSymbol(sym, options, exe_ctx)
     elif args[0].startswith('0x'):
-        sym = ds.getTarget().ResolveLoadAddress(long(args[0], 16)).GetSymbol()
-        output += generateAssemblyFromSymbol(sym, options)
+        sym = target.ResolveLoadAddress(long(args[0], 16)).GetSymbol()
+        output += generateAssemblyFromSymbol(sym, options, exe_ctx)
     elif args[0].isdigit():
-        sym = ds.getTarget().ResolveLoadAddress(long(args[0])).GetSymbol()
-        output += generateAssemblyFromSymbol(sym, options)
+        sym = target.ResolveLoadAddress(long(args[0])).GetSymbol()
+        output += generateAssemblyFromSymbol(sym, options, exe_ctx)
     else:
         cleanCommand = ' '.join(args)
         symList = target.FindGlobalFunctions(cleanCommand, 0, lldb.eMatchTypeNormal)    
@@ -50,12 +50,12 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
             result.SetError(ds.attrStr("Couldn't find any matches for \"{}\"".format(cleanCommand), 'red'))
             return
         sym = symList
-        output += generateAssemblyFromSymbol(symList.GetContextAtIndex(0).symbol, options)
+        output += generateAssemblyFromSymbol(symList.GetContextAtIndex(0).symbol, options, exe_ctx)
 
     result.AppendMessage(output)
 
-def generateAssemblyFromSymbol(sym, options):
-    target = ds.getTarget()
+def generateAssemblyFromSymbol(sym, options, exe_ctx):
+    target = exe_ctx.target
     instructions = sym.GetInstructions(target)
     output = ds.attrStr(str(sym.addr.module.file.basename) + ', ', 'cyan') + ds.attrStr(str(sym.name), 'yellow') + '\n'
     counter = 0
@@ -63,8 +63,6 @@ def generateAssemblyFromSymbol(sym, options):
     if len(instructions) == 0:
         return
     startAddress = instructions.GetInstructionAtIndex(0).GetAddress().GetLoadAddress(target)
-
-    frame = ds.getFrame()
 
     branches = []
     offsetSizeDict = {}
@@ -101,8 +99,8 @@ def generateAssemblyFromSymbol(sym, options):
                 nextPCAddr = hex(nextInst.addr.GetLoadAddress(target))
                 commentLoadAddr = eval(m.group(0).replace('rip', nextPCAddr))
 
-                addr = ds.getTarget().ResolveLoadAddress(commentLoadAddr)
-                showComments, modName = generateDescriptionByAddress(addr)
+                addr = target.ResolveLoadAddress(commentLoadAddr)
+                showComments, modName = generateDescriptionByAddress(addr, target)
                 if not showComments:
                     comments = ''
 
@@ -167,8 +165,7 @@ def generateAssemblyFromSymbol(sym, options):
     return output + '\n'
 
 
-def generateDescriptionByAddress(addr):
-    target = ds.getTarget()
+def generateDescriptionByAddress(addr, target):
     section = addr.section
     name = ''
     retDescription = ''

--- a/lldb_commands/ds.py
+++ b/lldb_commands/ds.py
@@ -68,13 +68,6 @@ def isProcStopped():
         return True 
     return False
 
-def getFrame(error=None):
-    frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
-    # if frame is None and error is not None:
-    #     pass # TODO
-    return frame
-
-
 def getSectionName(section):
         name = section.name
         parent = section.GetParent()

--- a/lldb_commands/ds.py
+++ b/lldb_commands/ds.py
@@ -125,7 +125,7 @@ def create_or_touch_filepath(filepath, contents):
     file.flush()
     file.close()
 
-def copy(debugger, command, result, internal_dict):
+def copy(debugger, command, exe_ctx, result, internal_dict):
     res = lldb.SBCommandReturnObject()
     debugger = lldb.debugger
     interpreter = debugger.GetCommandInterpreter()
@@ -605,7 +605,7 @@ def getType(typeStr, count=None):
     return t
 
 
-def sys(debugger, command, result, internal_dict):
+def sys(debugger, command, exe_ctx, result, internal_dict):
     search =  re.search('(?<=\$\().*(?=\))', command)
     if search:
         cleanCommand = search.group(0)

--- a/lldb_commands/fileoffsetbreakpoint.py
+++ b/lldb_commands/fileoffsetbreakpoint.py
@@ -32,7 +32,7 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
         result.SetError(parser.usage)
         return 
 
-    target = debugger.GetSelectedTarget()
+    target = exe_ctx.target
     module = target.module[args[0]]
     try: 
         offset = long(args[1], 16)

--- a/lldb_commands/fileoffsetbreakpoint.py
+++ b/lldb_commands/fileoffsetbreakpoint.py
@@ -9,7 +9,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
     'command script add -f fileoffsetbreakpoint.handle_command lbr')
 
-def handle_command(debugger, command, result, internal_dict):
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
     '''
     Creates a breakpoint on the fileoffset of a module and resolves 
     to the load address in memory. 

--- a/lldb_commands/generate_new_script.py
+++ b/lldb_commands/generate_new_script.py
@@ -31,7 +31,7 @@ def __lldb_init_module(debugger, internal_dict):
         'command script add -f generate_new_script.generate_new_script __generate_script')
 
 
-def generate_new_script(debugger, command, result, internal_dict):
+def generate_new_script(debugger, command, exe_ctx, result, internal_dict):
     '''
     Generates a new script in the same directory as this file.
     Can generate function styled scripts or class styled scripts.
@@ -146,7 +146,7 @@ def __lldb_init_module(debugger, internal_dict):
     script += '\'command script add -f {}.handle_command {}\')'.format(filename, resolved_name)
     script += r'''
 
-def handle_command(debugger, command, result, internal_dict):
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
     ''' 
     script += "\'\'\'\n    Documentation for how to use " + resolved_name + " goes here \n    \'\'\'"
     

--- a/lldb_commands/iap.py
+++ b/lldb_commands/iap.py
@@ -31,7 +31,7 @@ def __lldb_init_module(debugger, internal_dict):
         'command script add -f iap.iap iap')
 
 
-def iap(debugger, command, result, internal_dict):
+def iap(debugger, command, exe_ctx, result, internal_dict):
     '''
     iap expects at least one argument. The following arguments are currently supported
 

--- a/lldb_commands/lookup.py
+++ b/lldb_commands/lookup.py
@@ -32,7 +32,7 @@ def __lldb_init_module(debugger, internal_dict):
         'command script add -f lookup.lookup lookup')
 
 
-def lookup(debugger, command, result, internal_dict):
+def lookup(debugger, command, exe_ctx, result, internal_dict):
     '''
     Perform a regular expression search for stuff in an executable
 

--- a/lldb_commands/msl.py
+++ b/lldb_commands/msl.py
@@ -31,8 +31,8 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
         return
 
     cleanCommand = args[0]
-    frame = debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
-    target = debugger.GetSelectedTarget()
+    frame = exe_ctx.frame
+    target = exe_ctx.target
     script = generateScript(cleanCommand, options)
     sbval = frame.EvaluateExpression(script, generateOptions())
 

--- a/lldb_commands/msl.py
+++ b/lldb_commands/msl.py
@@ -11,7 +11,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
     'command script add -f msl.handle_command msl')
 
-def handle_command(debugger, command, result, internal_dict):
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
     '''
     msl 0xadd7E55
 

--- a/lldb_commands/overlaydbg.py
+++ b/lldb_commands/overlaydbg.py
@@ -17,7 +17,7 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
     Toggles the UIDebuggingInformationOverlay, iOS 9.X - 11.X only
     '''
 
-    target = debugger.GetSelectedTarget()
+    target = exe_ctx.target
     if GlobalProcess.hasPerformedSetup is False:
         setupIfiOS11(target)
         debugger.HandleCommand('exp -lobjc -O -- [UIDebuggingInformationOverlay prepareDebuggingOverlay]')

--- a/lldb_commands/overlaydbg.py
+++ b/lldb_commands/overlaydbg.py
@@ -12,7 +12,7 @@ def __lldb_init_module(debugger, internal_dict):
 class GlobalProcess:
     hasPerformedSetup = False
 
-def handle_command(debugger, command, result, internal_dict):
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
     '''
     Toggles the UIDebuggingInformationOverlay, iOS 9.X - 11.X only
     '''

--- a/lldb_commands/pmodule.py
+++ b/lldb_commands/pmodule.py
@@ -33,7 +33,7 @@ def __lldb_init_module(debugger, internal_dict):
         'command script add -f pmodule.pmodule pmodule')
 
 
-def pmodule(debugger, command, result, internal_dict):
+def pmodule(debugger, command, exe_ctx, result, internal_dict):
     '''Creates a custom dtrace script that profiles modules in an executable
     based upon its memory layout and ASLR. Provide no arguments w/ '-a' if 
     you want a count of all the modules firing. Provide a module if you want 

--- a/lldb_commands/pmodule.py
+++ b/lldb_commands/pmodule.py
@@ -58,21 +58,21 @@ def pmodule(debugger, command, exe_ctx, result, internal_dict):
 
     command_args = shlex.split(command)
     parser = generate_option_parser()
-    target = debugger.GetSelectedTarget()
+    target = exe_ctx.target
     try:
         (options, args) = parser.parse_args(command_args)
     except:
         result.SetError("option parsing failed")
         return
-    pid = target.process.id
+    pid = exe_ctx.process.id
 
-    # module_parirs = get_module_pair(, debugger)
+    # module_parirs = get_module_pair(, target)
     is_cplusplus = options.non_objectivec
     if not args and not (options.all_modules or options.all_modules_output):
         result.SetError('Need a module or use the -a option. You can list all modules by "image list -b"')
         return
 
-    dtrace_script = generate_dtrace_script(debugger, options, args)
+    dtrace_script = generate_dtrace_script(target, options, args)
     if options.debug:
         source = '\n'.join(['# '+ format(idx + 1, '2') +': ' + line for idx, line in enumerate(dtrace_script.split('\n'))]) 
 
@@ -93,8 +93,8 @@ def pmodule(debugger, command, exe_ctx, result, internal_dict):
     
     result.SetStatus(lldb.eReturnStatusSuccessFinishNoResult)
 
-def generate_conditional_for_module_name(module_name, debugger, options):
-    pair = get_module_pair(module_name, debugger)
+def generate_conditional_for_module_name(module_name, target, options):
+    pair = get_module_pair(module_name, target)
     if not options.non_objectivec and options.root_function:
         template = '/ ({0} > *(uintptr_t *)copyin(uregs[R_SP], sizeof(uintptr_t)) || *(uintptr_t *)copyin(uregs[R_SP], sizeof(uintptr_t)) > {1}) && {0} <= uregs[R_PC] && uregs[R_PC] <= {1} /\n'
     elif options.non_objectivec and not options.root_function:
@@ -134,8 +134,7 @@ def create_or_touch_filepath(filepath, dtrace_script):
     os.chmod(filepath, st.st_mode | S_IEXEC)
     file.close()
 
-def generate_dtrace_script(debugger, options, args):
-    target = debugger.GetSelectedTarget()
+def generate_dtrace_script(target, options, args):
     is_cplusplus = options.non_objectivec
     dtrace_script = '''#!/usr/sbin/dtrace -s
 #pragma D option quiet
@@ -191,12 +190,12 @@ dtrace:::BEGIN
             # Objective-C logic:        objc$target:::entry / {} <= uregs[R_PC] && uregs[R_PC] <= {} / { }
             if not is_cplusplus:
                 dtrace_script += query_template.format('objc', '')
-                dtrace_script += generate_conditional_for_module_name(module_name, debugger, options)
+                dtrace_script += generate_conditional_for_module_name(module_name, target, options)
 
             # Non-Objective-C logic:    pid$target:Module::entry { }
             if is_cplusplus:
                 dtrace_script += query_template.format('pid', module_name)
-                dtrace_script += generate_conditional_for_module_name(module_name, debugger, options)
+                dtrace_script += generate_conditional_for_module_name(module_name, target, options)
                 dtrace_script += '{\n    printf("[%s] %s\\n", probemod, probefunc);\n'
             else:
                 dtrace_script += '{\n    printf("0x%012p %c[%s %s]\\n", uregs[R_RDI], probefunc[0], probemod, (string)&probefunc[1]);\n'
@@ -211,9 +210,7 @@ dtrace:::BEGIN
     return dtrace_script
 
 
-def get_module_pair(module_name, debugger):
-    target = debugger.GetSelectedTarget()
-
+def get_module_pair(module_name, target):
     module = target.FindModule(lldb.SBFileSpec(module_name))
     if not module.file.exists:
         result.SetError(

--- a/lldb_commands/sbt.py
+++ b/lldb_commands/sbt.py
@@ -46,9 +46,8 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
         return
 
 
-    target = debugger.GetSelectedTarget()
-    process = target.GetProcess()
-    thread = process.GetSelectedThread()
+    target = exe_ctx.target
+    thread = exe_ctx.thread
     if thread is None:
         result.SetError('LLDB must be paused to execute this command')
         return

--- a/lldb_commands/sbt.py
+++ b/lldb_commands/sbt.py
@@ -30,7 +30,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
     'command script add -f sbt.handle_command sbt')
 
-def handle_command(debugger, command, result, internal_dict):
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
     '''
     Symbolicate backtrace. Will symbolicate a stripped backtrace
     from an executable if the backtrace is using Objective-C 

--- a/lldb_commands/sclass.py
+++ b/lldb_commands/sclass.py
@@ -75,7 +75,7 @@ Examples:
     interpreter.HandleCommand('expression -lobjc -O -- @import ObjectiveC', res)
     res.Clear()
 
-    target = debugger.GetSelectedTarget()
+    target = exe_ctx.target
     interpreter.HandleCommand('expression -lobjc -O -- (Class)NSClassFromString(@\"{}\")'.format(clean_command), res)
     if 'nil' in res.GetOutput():
         result.SetError('Can\'t find class named "{}". Womp womp...'.format(clean_command))

--- a/lldb_commands/sclass.py
+++ b/lldb_commands/sclass.py
@@ -32,7 +32,7 @@ def __lldb_init_module(debugger, internal_dict):
         'command script add -f sclass.sclass sclass')
 
 
-def sclass(debugger, command, result, internal_dict):
+def sclass(debugger, command, exe_ctx, result, internal_dict):
     '''
     Swizzle Class. Generates a NSObject category file 
     that swizzles the class that you supply. 

--- a/lldb_commands/search.py
+++ b/lldb_commands/search.py
@@ -89,7 +89,7 @@ Examples:
     interpreter = debugger.GetCommandInterpreter()
 
     if options.module:
-        target = debugger.GetSelectedTarget()
+        target = exe_ctx.target
         module = target.FindModule(lldb.SBFileSpec(options.module))
         if not module.IsValid():
             result.SetError(
@@ -117,7 +117,7 @@ Examples:
     expr_options.SetLanguage (lldb.eLanguageTypeObjC_plus_plus)
     expr_options.SetCoerceResultToId(True)
     # expr_options.SetAutoApplyFixIts(True)
-    frame = debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
+    frame = exe_ctx.frame
 
     if frame is None:
         result.SetError('You must have the process suspended in order to execute this command')

--- a/lldb_commands/search.py
+++ b/lldb_commands/search.py
@@ -43,7 +43,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand('command script add -f search.search search')
 
 
-def search(debugger, command, result, internal_dict):
+def search(debugger, command, exe_ctx, result, internal_dict):
     '''
     Finds all subclasses of a class. This class must by dynamic 
     (aka inherit from a NSObject class). Currently doesn't work 

--- a/lldb_commands/section.py
+++ b/lldb_commands/section.py
@@ -26,11 +26,12 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
     # Uncomment if you are expecting at least one argument
     # clean_command = shlex.split(args[0])[0]
 
+    target = exe_ctx.target
     if len(args) == 0:
         options.summary = True
         sections = [i for i in ds.getSection()]
     elif len(args) == 1:
-        module = args[0] if ds.getTarget().module[args[0]] else None
+        module = args[0] if target.module[args[0]] else None
         segment = args[0] if not module else None
         if segment and '.' in segment:
             if module:
@@ -38,7 +39,7 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
             else:
                 sections = [ds.getSection(module=None, name=args[0])]
         else:
-            # module = args[0] if ds.getTarget().module[args[0]] else None
+            # module = args[0] if target.module[args[0]] else None
             options.summary = True
             if module:
                 sections = ds.getSection(module=args[0], name=None)
@@ -57,19 +58,19 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
     if isinstance(sections, lldb.SBSection) and sections.GetNumSubSections() == 0:
         output = str(sections)
     else:
-        output = parseSection(sections, options)
+        output = parseSection(sections, options, target)
 
     
     result.AppendMessage(output)
 
 
-def parseSection(sections, options):
+def parseSection(sections, options, target):
     output = ''
     for section in sections:
         # if section 
 
         name = ds.getSectionName(section)
-        loadAddr = section.addr.GetLoadAddress(ds.getTarget())
+        loadAddr = section.addr.GetLoadAddress(target)
         addr = section.addr
         size = section.size
         data = section.data

--- a/lldb_commands/section.py
+++ b/lldb_commands/section.py
@@ -10,7 +10,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
     'command script add -f section.handle_command section')
 
-def handle_command(debugger, command, result, internal_dict):
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
     '''
     Documentation for how to use section goes here 
     '''

--- a/lldb_commands/snoopie.py
+++ b/lldb_commands/snoopie.py
@@ -25,8 +25,8 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
         return
 
 
-    script = generateDTraceScript(debugger, options)
-    pid = debugger.GetSelectedTarget().process.id
+    script = generateDTraceScript(exe_ctx.target, options)
+    pid = exe_ctx.process.id
     filename = '/tmp/lldb_dtrace_profile_snoopie.d'
     
     createOrTouchFilePath(filename, script)
@@ -45,8 +45,7 @@ def createOrTouchFilePath(filepath, dtrace_script):
     file.close()
 
 
-def generateDTraceScript(debugger, options):
-    target = debugger.GetSelectedTarget()
+def generateDTraceScript(target, options):
     path = target.executable.fullpath
     section = target.module[path].section['__DATA']
     start_address = section.GetLoadAddress(target)

--- a/lldb_commands/snoopie.py
+++ b/lldb_commands/snoopie.py
@@ -10,7 +10,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
     'command script add -f snoopie.handle_command snoopie')
 
-def handle_command(debugger, command, result, internal_dict):
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
     '''
     Generates a DTrace sciprt that will only profile classes implemented
     in the main executable irregardless if binary is stripped or not.

--- a/lldb_commands/tobjectivec.py
+++ b/lldb_commands/tobjectivec.py
@@ -13,7 +13,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
     'command script add -f tobjectivec.handle_command tobjectivec')
 
-def handle_command(debugger, command, result, internal_dict):
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
     '''
     Creates a dtrace script and copies to your clipboard
     sudo dtrace provider:module:function:name / predicate / { action }

--- a/lldb_commands/tobjectivec.py
+++ b/lldb_commands/tobjectivec.py
@@ -27,10 +27,10 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
         result.SetError(parser.usage)
         return
 
-    script = generateDTraceScript(debugger, options)
+    script = generateDTraceScript(options)
 
 
-    pid = debugger.GetSelectedTarget().process.id
+    pid = exe_ctx.process.id
     filename = '/tmp/lldb_dtrace_profile_objc.d'
 
     
@@ -54,7 +54,7 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
         result.AppendMessage("Copied script to clipboard... paste in Terminal")
 
 
-def generateDTraceScript(debugger, options):  
+def generateDTraceScript(options):  
     headers = '#!/usr/sbin/dtrace -{}s'.format('e' if options.debug_with_clipboard else 'l' if options.listprobes else '')
     script = headers + '\n\n'
     if not options.not_quiet:

--- a/lldb_commands/xref.py
+++ b/lldb_commands/xref.py
@@ -30,7 +30,7 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
     except:
         addr = int(args[0])
 
-    target = ds.getTarget()
+    target = exe_ctx.target
     sbaddress = target.ResolveLoadAddress(addr)
     if len(args) == 2:
         module = target.module[args[1]]
@@ -42,9 +42,9 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
     outputStr = ''
 
     if section.name == '__cstring':
-        outputStr += getCFAddress(sbaddress)
+        outputStr += getCFAddress(sbaddress, target)
     if section.name == '__objc_methname':
-        outputStr += getObjcMethNameAddress(sbaddress)
+        outputStr += getObjcMethNameAddress(sbaddress, target)
 
     executablePath = module.file.fullpath
     pagesizesection = ds.getSection(module.file.basename, name="__PAGEZERO")
@@ -84,13 +84,12 @@ def handle_command(debugger, command, exe_ctx, result, internal_dict):
             
         # print("match at {}".format(hex(resolved)))
 
-    outputStr += generateAddressInfo(resolvedAddresses, options)
+    outputStr += generateAddressInfo(resolvedAddresses, options, target)
     result.AppendMessage(outputStr)
 
-def getObjcMethNameAddress(addr):
+def getObjcMethNameAddress(addr, target):
     outputStr = ''
     section = addr.section
-    target = ds.getTarget()
     fileAddr = addr.file_addr
     executablePath = addr.module.file.fullpath
     dataSection = ds.getSection(module=executablePath, name='__DATA.__objc_selrefs')
@@ -111,10 +110,9 @@ def getObjcMethNameAddress(addr):
 
 
 
-def getCFAddress(addr):
+def getCFAddress(addr, target):
     outputStr = ''
     section = addr.section
-    target = ds.getTarget()
     fileAddr = addr.file_addr
     executablePath = addr.module.file.fullpath
     dataSection = ds.getSection(module=executablePath, name='__DATA.__cfstring')
@@ -138,8 +136,7 @@ def getCFAddress(addr):
             outputStr += '[{}] {}\n'.format(hex(startAddr.GetLoadAddress(target)), summary)
     return outputStr
 
-def generateAddressInfo(addresses, options):
-    target = ds.getTarget()
+def generateAddressInfo(addresses, options, target):
     outputStr = ''
     for a in addresses:
         symbol = a.symbol

--- a/lldb_commands/xref.py
+++ b/lldb_commands/xref.py
@@ -12,7 +12,7 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
     'command script add -f xref.handle_command xref')
 
-def handle_command(debugger, command, result, internal_dict):
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
     '''
     Documentation for how to use xref goes here 
     '''

--- a/lldb_commands/yoink.py
+++ b/lldb_commands/yoink.py
@@ -31,7 +31,7 @@ def __lldb_init_module(debugger, internal_dict):
         'command script add -f yoink.yoink yoink')
 
 
-def yoink(debugger, command, result, internal_dict):
+def yoink(debugger, command, exe_ctx, result, internal_dict):
     '''
     Takes a path on a iOS/tvOS/watchOS and writes to the /tmp/ dir on your computer.
     If it can be read by -[NSData dataWithContentsOfFile:], it can be written to disk


### PR DESCRIPTION
This change adds the `exe_ctx` parameter to each command. This parameter is a [`SBExecutionContext`](https://lldb.llvm.org/python_reference/lldb.SBExecutionContext-class.html)  which provides direct access to the `target`, `frame`, `process`, and `thread`.

In particular, this reduces the use of `ds.getTarget()`, which relied on the global `lldb.target`. The [lldb documentation](https://lldb.llvm.org/python-reference.html) (see "EMBEDDED PYTHON INTERPRETER") states this about the globals:

> they are only defined and meaningful while in the interactive Python interpreter. There is no guarantee on their value in any other situation, hence you should not use them when defining Python formatters, breakpoint scripts and commands

For information about the `exe_ctx` parameter, see "CREATE A NEW LLDB COMMAND USING A PYTHON FUNCTION" at https://lldb.llvm.org/python-reference.html