### PR TITLE
Lint README, fixed some headings and removed unused var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # LLDB
 
-<a href="https://store.raywenderlich.com/products/advanced-apple-debugging-and-reverse-engineering" target="_blank"><img align="right" src="Media/dbgbook.png"></a>
-A collection of LLDB aliases/regexes and Python scripts to aid in my debugging sessions. These scripts are built only for my  own amusement, but some of them might be helpful in your own work. If you want to gain a better understanding of how to build these LLDB scripts, or gain a better understanding of LLDB in general, check out <a href="https://store.raywenderlich.com/products/advanced-apple-debugging-and-reverse-engineering" target="_blank">**Advanced Apple Debugging and Reverse Engineering**</a>
+[![img](Media/dbgbook.png)](https://store.raywenderlich.com/products/advanced-apple-debugging-and-reverse-engineering)
 
+A collection of LLDB aliases/regexes and Python scripts to aid in my debugging sessions. These scripts are built only for my  own amusement, but some of them might be helpful in your own work. If you want to gain a better understanding of how to build these LLDB scripts, or gain a better understanding of LLDB in general, check out [**Advanced Apple Debugging and Reverse Engineering**](https://store.raywenderlich.com/products/advanced-apple-debugging-and-reverse-engineering).
 
-## Installation 
+## Installation
 
 1. To Install, copy the **lldb_commands** folder to a dir of your choosing.
 2. Open up (or create) **~/.lldbinit** 
@@ -14,7 +14,7 @@ Boom! You're good to go!
 
 You can test to make sure everything worked successfully by just trying one of the commands in the debugger... i.e. `(lldb) help methods`
 
-# LLDB Scripts
+## LLDB Scripts
 
 For all commands below, you can view the documentation via `help {command}`. If you want to see what options a command has, type `{command} -h`.
 
@@ -23,60 +23,62 @@ TLDR: `search`, `lookup`, and `dclass` are good GOTOs irregardless if you're a d
 If you like ObjC swizzling, check out `sclass`. If you like DTrace, check out `pmodule` and `snoopie`.
 
 ### search
-  Searchs the heap for all alive instances of a certain class. This class must by dynamic (aka inherit from a `NSObject`/`SwiftObject` class). Currently doesn't work with `NSString` or `NSNumber` (tagged pointer objects). 
+
+  Searchs the heap for all alive instances of a certain class. This class must by dynamic (aka inherit from a `NSObject`/`SwiftObject` class). Currently doesn't work with `NSString` or `NSNumber` (tagged pointer objects).
   
-  Example: 
+  Example:
   
       # Find all instances and subclasses of UIView
       (lldb)  search UIView
-      
+
       # Find all instances of UIView that are UIViews. Ignore subclasses.
       (lldb) search UIView -e
-      
+
       #Find all instances of UIView whose tag is equal to 5. Objective-C syntax only. Can reference object by 'obj'
       (lldb) search UIView -c "(int)[obj tag]==5"
-      
+
       # Find all instances of a UIView subclass whose class is implemented in the SpringBoardUI module
       (lldb) search UIView -m SpringBoardUI
-      
+
       # Find all UIView subclasses created in the "Woot" module and hide them
       (lldb) search UIView -m Woot -p "[obj setHidden:YES]"
-      
+
       # Search for UIViews but just print the class, don't print object description (ideal for Swift where they hide the pointer)
       (lldb) search UIView -b
-      
+
       # Remember, Swift includes the module in a class name, so if you have a Swift UIView called TestView in module WOOT...
       (lldb) search WOOT.TestView -b
-      
+
       # Search for all classes that contain a reference to the pointer 0xfeedfacf
       (lldb) search -r 0xfeedfacf
 
 ### dclass
+
 Dumps all the `NSObject`/`SwiftObject` inherited classes in the process. If you give it a module, it will dump only the classes within that module. You can also filter out classes to only a certain type and can also generate a header file for a specific class.
   
-  Example: 
+  Example:
   
       # Dump ALL the classes (Swift and Objective-C) found within the process
-      (lldb) dclass 
-      
+      (lldb) dclass
+
       # Dump ObjC/Swift info (if applicable) about the class "Hello.SomeClass" (same as dclass -i Hello.SomeClass)
       (lldb) dclass Hello.SomeClass
 
       # Dump all the classes that are a UIViewController within the process
       (lldb) dclass -f UIViewController
-      
+
       # Dump all the classes with the regex case insensitive search "viewcontroller" in the class name
       (lldb) dclass -r (?i)viewCoNtrolLer
-      
+
       # Dump all the classes within the UIKit module
       (lldb) dclass -m UIKit
 
       # Dump all classes in CKConfettiEffect NSBundle that are UIView subclasses
       (lldb) dclass /System/Library/Messages/iMessageEffects/CKConfettiEffect.bundle/CKConfettiEffect -f UIView
-      
+
       # Generate a header file for the class specified:
       (lldb) dclass -g UIView
-      
+
       # Generate a protocol that you can cast an object to. Ideal when working with private classes at dev time
       (lldb) dclass -P UIView
 
@@ -85,101 +87,104 @@ Dumps all the `NSObject`/`SwiftObject` inherited classes in the process. If you 
 
       # Only dump classes whose superclass is of type NSObjecr and in the UIKit module. Ideal for going after specific classes like a datasource where it will likely inherit from NSObject
       (lldb) dclass -s NSObject -m UIKit
-      
-      # Dump only Swift classes 
+
+      # Dump only Swift classes
       (lldb) dclass -t swift
-      
-      # Dump only Objective-C classes 
+
+      # Dump only Objective-C classes
       (lldb) dclass -t objc
-      
+
       # Get a simplified "class-dump" of the UIView class
       (lldb) dclass -i UIView
-      
+
       # Get more information than you ever wanted to know about UIView
       (lldb) dclass -I UIView
-      
 
 ### section
+
 Displays data in the Mach-O segments/sections of the executable or frameworks loaded into the proc
 
       # Dump the Mach-O segments to the main executable
       (lldb) section
-      
+
       # Dump the Mach-O segments to UIKit
       (lldb) section UIKit
-      
+
       # Dump the Mach-O sections of the __TEXT segment of UIKit
       (lldb) section UIKit __TEXT
-      
+
       # Get the load address of all the hard-coded uint8_t * strings in the UIKit binary
       (lldb) section UIKit __TEXT.__cstring -l
-      
+
       # Get the entitlements for the executable (simulator only, entitlements for actual app in __LINKEDIT)
       (lldb) section  __TEXT.__entitlements
-      
+
       # Get all the load address to the lazy symbol stubs in the main executable
-      (lldb) section  __DATA.__la_symbol_ptr -l 
+      (lldb) section  __DATA.__la_symbol_ptr -l
 
 ### dd
+
 Alternative to LLDB's `disassemble` command. Uses colors. Terminal only and designed for x86)64. ARM64 support will come one day...
 ![yoink example](https://github.com/DerekSelander/LLDB/raw/master/Media/dd.png)
 
 ### sbt
-      Symbolicate backtrace. Will symbolicate a stripped backtrace from an executable if the backtrace is using Objective-C 
+
+      Symbolicate backtrace. Will symbolicate a stripped backtrace from an executable if the backtrace is using Objective-C
       code. Currently doesn't work on aarch64 stripped executables but works great on x64 :]
-      
+
       You learn how to make this command in the book :]
-      
 
 ![sbt example](https://github.com/DerekSelander/LLDB/raw/master/Media/sbt_gif.gif)
 
 ### msl
 
       msl 0xadd7e55
-      msl or malloc stack logging will take an address and try and obtain the stack trace to 
+      msl or malloc stack logging will take an address and try and obtain the stack trace to
       when it was created. 
 
       You will need to set the env var to MallocStackLogging, or `execute turn_on_stack_logging(1)`
       while the process is active
-      
+
       You learn how to make this command in the book :]
-      
-![msl example](https://github.com/DerekSelander/LLDB/raw/master/Media/msl_gif.gif) 
+
+![msl example](https://github.com/DerekSelander/LLDB/raw/master/Media/msl_gif.gif)
 
 ### lookup
+
 Perform a regular expression search for stuff in an executable
 
   Example:
   
       # Find all methods that contain the phrase viewDidLoad
       (lldb) lookup viewDidLoad
-      
+
       # Find a summary of all the modules that have a (known) function containing the phrase viewDidLoad
       (lldb) lookup viewDidLoad -s
-      
+
       # Search for Objective-C code in a stripped module (i.e. in SpringBoard)
       (lldb) loo -x StocksFramework .
-      
+
       # Search for Objective-C code containing the case insensitive phrase init inside a stripped main bundle
       (lldb) lookup -X (?i)init
-      
+
       # Search for all hardcoded, embeded `char *` inside an executable containing the phrase *http* inside UIKit
       (lldb) lookup -S http -m UIKit
-      
+
       # Dump all the md5'd base64 keys in libMobileGestalt along w/ the address in memory
       (lldb) loo -S ^[a-zA-Z0-9\+]{22,22}$ -m libMobileGestalt.dylib -l
-      
+
       # Dump all the global bss code referenced by DWARF. Ideal for accessing `static` variables when not in scope
       (lldb) lookup . -g HonoluluArt -l
-      
+
 ### biof
+
     Break if on func. Syntax: biof [ModuleName] regex1 ||| [ModuleName2] regex2
     Regex breakpoint that takes two regex inputs. The first regex creates a breakpoint on all matched functions.
     The second regex will make a breakpoint condition to stop only if the second regex breakpoint is in the stack trace
-    
+
     For example, to only stop if code in the "TestApp" module resulted in executing the setTintColor: method being called
-    biof setTintColor: ||| . Test 
-    
+    biof setTintColor: ||| . Test
+
     As a tip, it would be wise to have a limited regex1 that matches a small amount of functions, while keeping regex2 at any size
 
 ### yoink
@@ -187,18 +192,18 @@ Perform a regular expression search for stuff in an executable
   Takes a path on a iOS/tvOS/watchOS and writes to the **/tmp/** dir on your computer.
   If it can be read by `-[NSData dataWithContentsOfFile:]`, it can be written to disk
 
-  Example (on iOS 10 device): 
-  
+  Example (on iOS 10 device):
+
       (lldb) yoink /System/Library/Messages/iMessageEffects/CKConfettiEffect.bundle/CKConfettiEffect
 
 ![yoink example](https://github.com/DerekSelander/LLDB/raw/master/Media/yoink_gif.gif)
 
 ### pmodule
 
-  Creates a custom dtrace script that profiles modules in an executable based upon its 
-  memory layout and ASLR. Provide no arguments w/ '-a' if you want a count of all the modules firing. 
-  Provide a module if you want to dump all the methods as they occur. The location of the script is 
-  copied to your computer so you can paste the soon to be executed dtrace script in the Terminal. 
+  Creates a custom dtrace script that profiles modules in an executable based upon its
+  memory layout and ASLR. Provide no arguments w/ '-a' if you want a count of all the modules firing.
+  Provide a module if you want to dump all the methods as they occur. The location of the script is
+  copied to your computer so you can paste the soon to be executed dtrace script in the Terminal.
   
   WARNING: YOU MUST DISABLE ROOTLESS TO USE DTRACE
   
@@ -207,91 +212,97 @@ Perform a regular expression search for stuff in an executable
 
       # Trace all non-Objective-C code in libsystem_kernel.dylib (i.e. pid$target:libsystem_kernel.dylib::entry)
       (lldb) pmodule -n libsystem_kernel.dylib
-      
+
       # Dump errrything. Only displays count of function calls from modules after you end the script. Warning slow
       (lldb) pmodule -a
-      
+
 ![pmodule example](https://github.com/DerekSelander/LLDB/raw/master/Media/pmodule_gif.gif)
 
 ### snoopie
+
     Generates a DTrace sciprt that will only profile classes implemented
-    in the main executable irregardless if binary is stripped or not. This is done via 
+    in the main executable irregardless if binary is stripped or not. This is done via
     profiling objc_msgSend. The creation of this command is discussed in the book.
 
   WARNING: YOU MUST DISABLE ROOTLESS TO USE DTRACE
   
-
 ## LLDB Commands
 
-### ls 
-List a directory from the process's perspective. Useful when working on an actual device. 
-      
+### ls
+
+List a directory from the process's perspective. Useful when working on an actual device.
+
       # List the root dir's contents on an actual iOS device
       (lldb) ls /
-      
+
       # List contents for /System/Library on an actual iOS device
       (lldb) ls /System/Library
-      
+
 ### reload_lldbinit
+
 Reloads all the contents in your ~/.lldbinit file. Useful for seeing if your python script(s) broke or want to do incremental updates to a python script
 
     # Reload/Refresh your LLDB scripts
     (lldb) reload_lldbinit
 
 ### tv
+
 Toggle view. Hides/Shows a view depending on it's current state. You don't need to resume LLDB to see changes. ObjC only
 
     # Toggle a view on or off
     (lldb) tv [UIView new]
 
 ### pprotocol
+
 Dumps all the required and optional methods for specific protocol (Objective-C only)
 
     # Dump the protocol for UITableViewDataSource
     (lldb) pprotocol UITableViewDataSource
 
 ### pexecutable
+
 Prints the location (on disk) of the filepath to the executable
 
     (lldb) pexecutable
 
 ### pframework
+
 Prints the location (on disk) of a framework
 
     (lldb) pframework UIKit
 
 ### sys
+
 Drops into the shell to execute commands. Note you can execute LLDB commands via the $() syntax
-    
+
     # ls the directory LLDB is running in
     (lldb) sys ls
 
     # Use otool -l on the UIKit framework
     (lldb) sys otool -l $(pframework UIKit)
-    
+
     # Open the main executable in another program
     (lldb) sys open -a "Hopper" $(pexecutable)
 
-### methods 
+### methods
+
 Dumps all methods inplemented by the NSObject subclass (iOS, NSObject subclass only)
 
     # Get all the methods of UIView
-    (lldb) methods UIView 
-
+    (lldb) methods UIView
 
 ### ivars
+
 Dumps all ivars for an instance of a particular class which inherits from NSObject (iOS, NSObject subclass only)
 
     # Get all the ivars on a newly created instance of UIView
     (lldb) ivars [UIView new]
-    
 
-### overlaydbg
+## overlaydbg
+
 Displays the UIDebuggingInformationOverlay on iOS in 11. Check out http://ryanipete.com/blog/ios/swift/objective-c/uidebugginginformationoverlay/ for instructions
 
     # Display UIDebuggingInformationOverlay
     (lldb) overlaydbg
-    
 
-  
-You read all the way to here!? <a href="https://vimeo.com/231806976">Here's a video highlighting some of these scripts</a>
+You read all the way to here!? [Here's a video highlighting some of these scripts](https://vimeo.com/231806976)

--- a/lldb_commands/overlaydbg.py
+++ b/lldb_commands/overlaydbg.py
@@ -37,8 +37,6 @@ def setupIfiOS11(target):
 
     versionval = target.EvaluateExpression('[[UIDevice currentDevice] systemVersion]', options)
     versionvalstr = versionval.description 
-    
-    debugger = target.GetDebugger()
 
     if "11." in versionvalstr:
         tweakiOS11Memory(target, "UIKit")


### PR DESCRIPTION
# What does this PR do?

* Basically fixed some linting warnings that I found when opening `README.md` on vscode: section hierarchies, spaces, newlines, etc, replaced html `a` to markdown image (not sure if you want those replaced 🤔)
* Removed an unused var from the `overlaydbg.py` script that _linter_ was whining about:
```python
debugger = target.GetDebugger()
```

* Tested on Xcode and it still works flawlessly 🎉 