### PR TITLE
2 to 3 compat fixes

### DIFF
--- a/lldb_commands/cmds.txt
+++ b/lldb_commands/cmds.txt
@@ -46,7 +46,7 @@ command regex mload 's/(.+)/expression -lobjc -O -- void *handle = (void *)dlope
 
 command alias lnetwork expression -lobjc -O --   const char *className = (const char *)[[@"URLProtocolObserver" stringByAppendingString: [@((uint32_t)arc4random()) stringValue]] UTF8String];  Class cls = objc_allocateClassPair((Class)NSClassFromString(@"NSURLProtocol"), className, 0);  objc_registerClassPair(cls);    Method m = (Method)class_getClassMethod((Class)NSClassFromString(@"NSURLProtocol"), @selector(canInitWithRequest:));    class_addMethod((Class)objc_getMetaClass(className), @selector(canInitWithRequest:), (id (*)(__strong id, SEL, ...))imp_implementationWithBlock(^(id cls, id request){        id url = [request URL];    id path = [url absoluteString];        printf("%s\n\n", (char *)[[request debugDescription] UTF8String]);        return NO;  }) , (char *)method_getTypeEncoding(m));    [cls performSelector:@selector(registerClass:) withObject:cls];
 
-command regex gdocumentation 's/(.+)/script import os; os.system("open https:" + unichr(47) + unichr(47) + "lldb.llvm.org" + unichr(47) + "python_reference" + unichr(47) + "lldb.%1-class.html")/'
+command regex gdocumentation 's/(.+)/script from compat import unichr; import os; os.system("open https:" + unichr(47) + unichr(47) + "lldb.llvm.org" + unichr(47) + "python_reference" + unichr(47) + "lldb.%1-class.html")/'
 
 command regex pbpaste 's/(.+)/expression -l objc -O -- [[UIPasteboard generalPasteboard] setString:@"%1"]/'
 

--- a/lldb_commands/compat/__init__.py
+++ b/lldb_commands/compat/__init__.py
@@ -7,8 +7,17 @@
 # So later you can do things like:
 # from compat import thing_in_compat
 
+# unichr compatibility shim
+# In Python 3, use chr instead
+# When needed, do:
+# from compat import unichr
+#
+# We need to do this here because you can't squash
+# the exception handling into a one-line 'command script'
 try:
     _ = unichr(0)
+    # We need to actually do this assignment in order to
+    # export it in __all__
     unichr = unichr
 except NameError:
     unichr = chr

--- a/lldb_commands/compat/__init__.py
+++ b/lldb_commands/compat/__init__.py
@@ -1,0 +1,17 @@
+# Glue code here to make stuff work in both python2 and python 3
+# In particular:
+# - things that are needed for 'command script' usages so multi-line constructs like exceptions won't work
+# - things that would otherwise rely on extra installed packages like python-future
+
+# Note: When dslldb.py gets 'command script import'ed, its path gets added to sys.path,
+# So later you can do things like:
+# from compat import thing_in_compat
+
+try:
+    _ = unichr(0)
+    unichr = unichr
+except NameError:
+    unichr = chr
+
+
+__all__ = [unichr]


### PR DESCRIPTION
Created a compat module where you can put python 2/3 compatibility glue.

This especially useful for one-line `command script` invocations that can't have complicated compatibility logic. So now you can do:

`command script "from compat import unichr; do_stuff(unichr(32))"`
