### PR TITLE
add cbd script: disabling a breakpoint stopped currently

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ Paste selected text from your mac to your iOS device. (No args, but make sure yo
 
 Delete breakpoint by address 
 
+### cbd
+
+Disables a breakpoint stopped currently and continues process
+
 ### data
 
 Dump the bytes of a NSData object

--- a/lldb_commands/cbd.py
+++ b/lldb_commands/cbd.py
@@ -1,0 +1,75 @@
+# MIT License
+
+# Copyright (c) 2021 Kazutoshi Miyasaka
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import lldb
+import os
+import re
+import optparse
+import shlex
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand('command script add -f cbd.handle_command cbd')
+
+def handle_command(debugger, command, result, internal_dict):
+    '''
+    Disables a breakpoint currently stopped and continue process.
+    '''
+    command_args = shlex.split(command, posix=False)
+    parser = generateOptionParser()
+
+    try:
+        (options, args) = parser.parse_args(command_args)
+    except:
+        result.SetError(parser.usage)
+        return
+    
+    target = debugger.GetSelectedTarget()
+    process = target.GetProcess()
+    thread = process.GetSelectedThread()
+
+    count = thread.GetStopReasonDataCount()
+    breakpoints = ""
+    for i in range(0, count, 2):
+        main = thread.GetStopReasonDataAtIndex(i)
+        sub  = thread.GetStopReasonDataAtIndex(i + 1)       
+        breakpoints = breakpoints + "{0}.{1} ".format(main, sub)
+
+    if breakpoints.strip():
+        delete_or_disable_string = "delete" if options.should_delete else "disable"
+        exp = "break {0} {1}".format(delete_or_disable_string, breakpoints)
+        
+        res = lldb.SBCommandReturnObject()
+        debugger.GetCommandInterpreter().HandleCommand(exp, res)
+        if res.GetError():  
+            result.SetError(res.GetError()) 
+        print(exp)
+
+    if not options.should_stay:
+        debugger.SetAsync(True)
+        process.Continue()
+
+def generateOptionParser():
+  usage = "Use 'cbd -h' for option desc"
+  parser = optparse.OptionParser(usage=usage, prog='cbd') 
+  parser.add_option("-d", "--delete", action="store_true", default=False, dest="should_delete", help="deleting breakpoint")
+  parser.add_option("-s", "--stay", action="store_true", default=False, dest="should_stay", help="staying at the point after the excution")
+  return parser


### PR DESCRIPTION
**What**
`cbd` is a command.
It means "**c**urrent **b**reakpoint **d**isable or **d**elete".
By this command, developers can disable or delete a breakpoint stopped currently easily.

**Why**
When I set breakpoint with `rbreak` for reverse-engineering, massive breakpoint are made sometimes and
furthermore the process often stops at same symbols many times.
In this case, it' bothering to delete unnecessary breakpoints by specifying breakpoint number (e.g. `break delete  1.585 `)
so I made this command.

**How**
<img width="158" alt="Screen Shot 2021-09-19 at 8 47 38" src="https://user-images.githubusercontent.com/14083051/133911243-612e1c91-2334-4cdb-8102-3a9e40e20635.png">
**Options**
```
(lldb) cbd -s // not continuing the process after disabling the breakpoint

(lldb) cbd -d // deleting the breakpoint 
```

P.S. 
I'm a reader of [your book](https://www.raywenderlich.com/books/advanced-apple-debugging-reverse-engineering/v3.0)
Thanks for this amazing book changing my life.