### PR TITLE
Use correct command name in help output

### DIFF
--- a/lldb_commands/search.py
+++ b/lldb_commands/search.py
@@ -56,16 +56,16 @@ def search(debugger, command, exe_ctx, result, internal_dict):
 Examples:
 
     # Find all UIViews and subclasses of UIViews
-    find UIView
+    search UIView
 
     # Find all UIStatusBar instances
-    find UIStatusBar
+    search UIStatusBar
 
     # Find all UIViews, ignore subclasses
-    find UIView  -e
+    search UIView -e
 
     # Find all instances of UIViews (and subclasses) where tag == 5
-    find UIView -c "[obj tag] == 5"
+    search UIView -c "[obj tag] == 5"
     '''
 
     if not ds.isProcStopped():
@@ -81,7 +81,7 @@ Examples:
         return
 
     if not args:
-        result.SetError('Usage: find NSObjectSubclass\n\nUse \'help find\' for more details')
+        result.SetError('Usage: search NSObjectSubclass\n\nUse \'help search\' for more details')
         return
 
     clean_command = ('').join(args)


### PR DESCRIPTION
`find` isn't a known command, it's `search`.