### PR TITLE
Fix TypeError in ds.py

### DIFF
--- a/lldb_commands/ds.py
+++ b/lldb_commands/ds.py
@@ -1003,8 +1003,8 @@ def sys(debugger, command, exe_ctx, result, internal_dict):
     output = subprocess.Popen(command, stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=True, env=my_env).communicate()
     retOutput = ''
     if output[1]:
-        retOutput += output[1]
-    retOutput += output[0].decode("utf-8") 
+        retOutput += output[1].decode("utf-8")
+    retOutput += output[0].decode("utf-8")
     result.AppendMessage(retOutput)
 
 


### PR DESCRIPTION
Fix TypeError (adding bytes to string) that occurs when calling:
`(lldb) sys echo "$(dclass -t swift)" | grep -v _ | grep "\." | cut -d. -f1 | uniq | wc -l` 
from 4th edition 1.2

macOS 15.0.1 (24A348) /  Xcode 16.2 / Python 3.13.1